### PR TITLE
Fix for OUJS

### DIFF
--- a/src/userstylesorg_css_highlighter.user.js
+++ b/src/userstylesorg_css_highlighter.user.js
@@ -14,7 +14,7 @@
 // 1.1 fresh versions of formater/hiliter; switching  butifying on/off; fixed &lt;/&amp; issue
 //
 // @author          trespassersW
-// @license         MIT License
+// @license         MIT
 // @released        2013-11-20
 // @updated         2016-01-04
 // @grant  GM_setClipboard


### PR DESCRIPTION
OUJS has made a change recently to require SPDX codes for OSI approved licensing.

In order to improve the appearance of your script homepages it would be appreciated if you could modify your affected script. These are syntactically equivalent.

Until this change is made you will be unable to update this affected script.

Thanks,
OUJS Staff